### PR TITLE
Improve responsive navigation

### DIFF
--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 
 const NavBar = () => {
   const [scrolled, setScrolled] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
   useEffect(() => {
     const handleScroll = () => {
       const isScrolled = window.scrollY > 10;
@@ -17,6 +18,15 @@ const NavBar = () => {
         <Link to="/" className="logo">
           May's Portfolio
         </Link>
+        <button
+          className="menu-toggle lg:hidden"
+          onClick={() => setMenuOpen(!menuOpen)}
+        >
+          <img
+            src={menuOpen ? "/images/x.svg" : "/images/menu.svg"}
+            alt="menu"
+          />
+        </button>
         <nav className="desktop">
           <ul>
             <li className="group">
@@ -37,12 +47,36 @@ const NavBar = () => {
           </ul>
         </nav>
 
-        <a href="#contact" className="contact-btn group">
+        <a href="#contact" className="contact-btn group hidden sm:flex">
           <div className="inner">
             <span>Contact me</span>
           </div>
         </a>
       </div>
+      <nav className={`mobile-menu ${menuOpen ? "open" : ""}`}>
+        <ul>
+          <li className="group">
+            <Link to="/" onClick={() => setMenuOpen(false)}>
+              <span>Home</span> <span className="underline" />
+            </Link>
+          </li>
+          <li className="group">
+            <Link to="/about" onClick={() => setMenuOpen(false)}>
+              <span>About</span> <span className="underline" />
+            </Link>
+          </li>
+          <li className="group">
+            <Link to="/projects" onClick={() => setMenuOpen(false)}>
+              <span>Projects</span> <span className="underline" />
+            </Link>
+          </li>
+          <li>
+            <a href="#contact" onClick={() => setMenuOpen(false)}>
+              Contact me
+            </a>
+          </li>
+        </ul>
+      </nav>
     </header>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -141,6 +141,37 @@ section {
       }
     }
 
+    .menu-toggle {
+      @apply lg:hidden block;
+      img {
+        @apply size-6;
+      }
+    }
+
+    nav.mobile-menu {
+      @apply fixed inset-0 bg-[#f0eeff] flex-col items-center justify-center gap-8 lg:hidden hidden;
+
+      &.open {
+        @apply flex;
+      }
+
+      ul {
+        @apply flex flex-col items-center gap-8 text-xl;
+
+        li {
+          @apply text-[#333a7d] relative;
+
+          span {
+            @apply transition-colors duration-300 hover:text-white-50;
+          }
+
+          .underline {
+            @apply absolute -bottom-1 left-0 w-0 h-0.5 bg-white-50 transition-all duration-300 group-hover:w-full;
+          }
+        }
+      }
+    }
+
     .contact-btn {
       @apply flex;
 


### PR DESCRIPTION
## Summary
- add mobile menu state management to `NavBar`
- create hamburger menu and mobile navigation markup
- style new mobile navigation in CSS

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686fce968dd0832eb46c72f1a0f3638b