### PR TITLE
Improve performance via lazy loading and throttled scroll

### DIFF
--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -5,11 +5,18 @@ const NavBar = () => {
   const [scrolled, setScrolled] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   useEffect(() => {
+    let ticking = false;
     const handleScroll = () => {
-      const isScrolled = window.scrollY > 10;
-      setScrolled(isScrolled);
+      if (!ticking) {
+        window.requestAnimationFrame(() => {
+          const isScrolled = window.scrollY > 10;
+          setScrolled(isScrolled);
+          ticking = false;
+        });
+        ticking = true;
+      }
     };
-    window.addEventListener("scroll", handleScroll);
+    window.addEventListener("scroll", handleScroll, { passive: true });
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
   return (

--- a/src/sections/Contact.jsx
+++ b/src/sections/Contact.jsx
@@ -1,10 +1,14 @@
-import { useRef, useState } from "react";
+import { useRef, useState, lazy, Suspense } from "react";
 import emailjs from "@emailjs/browser";
 import { useMediaQuery } from "react-responsive";
 
 import TitleHeader from "../components/TitleHeader";
-import ContactExperienceMobile from "../components/models/hero_models/ContactExperienceMobile";
-import ContactExperience from "../components/models/hero_models/ContactExperience";
+const ContactExperienceMobile = lazy(() =>
+  import("../components/models/hero_models/ContactExperienceMobile")
+);
+const ContactExperience = lazy(() =>
+  import("../components/models/hero_models/ContactExperience")
+);
 
 const Contact = () => {
   const isMobile = useMediaQuery({ maxWidth: 768 });
@@ -113,7 +117,9 @@ const Contact = () => {
           </div>
           <div className="xl:col-span-7 min-h-96">
             <div className="bg-[#bc8fff] w-full h-[350px] sm:h-[450px] md:h-[600px] hover:cursor-grab rounded-3xl overflow-hidden">
-              {isMobile ? <ContactExperienceMobile /> : <ContactExperience />}
+              <Suspense fallback={<div className="h-full" />}>
+                {isMobile ? <ContactExperienceMobile /> : <ContactExperience />}
+              </Suspense>
             </div>
           </div>
         </div>

--- a/src/sections/Hero.jsx
+++ b/src/sections/Hero.jsx
@@ -1,12 +1,17 @@
 import { useGSAP } from "@gsap/react";
 import gsap from "gsap";
+import { lazy, Suspense } from "react";
 import { useMediaQuery } from "react-responsive";
 
 import Button from "../components/Button";
 import { words } from "../constants";
 
-import HeroEperienceSuper from "../components/models/hero_models/HeroEperienceSuper";
-import HeroExperienceSuperMobile from "../components/models/hero_models/HeroExperienceSuperMobile";
+const HeroEperienceSuper = lazy(() =>
+  import("../components/models/hero_models/HeroEperienceSuper")
+);
+const HeroExperienceSuperMobile = lazy(() =>
+  import("../components/models/hero_models/HeroExperienceSuperMobile")
+);
 
 const Hero = () => {
   const isMobile = useMediaQuery({ maxWidth: 768 });
@@ -71,7 +76,9 @@ const Hero = () => {
         {/* RIGHT: 3D Model or Visual */}
         <figure className="mt-20 lg:mt-0">
           <div className="hero-3d-layout hover:cursor-grab">
-            {isMobile ? <HeroExperienceSuperMobile /> : <HeroEperienceSuper />}
+            <Suspense fallback={<div className="h-[400px]" />}>
+              {isMobile ? <HeroExperienceSuperMobile /> : <HeroEperienceSuper />}
+            </Suspense>
           </div>
         </figure>
       </div>


### PR DESCRIPTION
## Summary
- throttle navbar scroll handler with requestAnimationFrame
- lazy load Spline 3D model components in Hero and Contact sections
- wrap lazy components with `<Suspense>` fallbacks

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6874291668d4832e90b5213a7121626d