### PR TITLE
Fix mobile overflow

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -7,7 +7,7 @@
 
 html,
 body {
-  width: 100dvw;
+  width: 100%;
   overflow-x: hidden;
   background-color: #f0eeff;
   color: black;
@@ -25,7 +25,7 @@ button {
 }
 
 section {
-  width: 100dvw;
+  width: 100%;
 }
 
 @theme {
@@ -467,7 +467,7 @@ section {
 
 /* marquee */
 .marquee {
-  width: 100dvw;
+  width: 100%;
   overflow: hidden;
   position: relative;
 }


### PR DESCRIPTION
## Summary
- fix mobile horizontal overflow by using width 100% instead of 100dvw

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6878fcfc88b8832e808cc973a8e7e706